### PR TITLE
fix(checkpoint): Fix sorting issue of checkpoint list in Redis storage（issue #76）

### DIFF
--- a/graph/checkpointing.go
+++ b/graph/checkpointing.go
@@ -127,14 +127,13 @@ func (cl *CheckpointListener[S]) saveCheckpoint(ctx context.Context, nodeName st
 // cleanupOldCheckpoints removes oldest checkpoints exceeding the max limit
 func (cl *CheckpointListener[S]) cleanupOldCheckpoints(ctx context.Context) {
 	// List checkpoints for this thread/execution
-	var checkpointID string
+	var checkpoints []*store.Checkpoint
+	var err error
 	if cl.threadID != "" {
-		checkpointID = cl.threadID
+		checkpoints, err = cl.store.ListByThread(ctx, cl.threadID)
 	} else {
-		checkpointID = cl.executionID
+		checkpoints, err = cl.store.List(ctx, cl.executionID)
 	}
-
-	checkpoints, err := cl.store.List(ctx, checkpointID)
 	if err != nil || len(checkpoints) <= cl.maxCheckpoints {
 		return
 	}


### PR DESCRIPTION
• Replace SMembers command with ZAdd/ZRange/ZRem commands in Redis storage to support version sorting and subsequent pagination queries • Use sorted sets in List and ListByThread methods to ensure checkpoints are correctly sorted by version • Fix bug in cleanup logic related to thread_id
• Add automatic cleanup functionality test cases for Redis storage