### PR TITLE
docs: update outdated usages of graph.NewStateGraph

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -88,7 +88,7 @@
 // The core graph construction and execution engine
 //
 //	// Create a state graph
-//	g := graph.NewStateGraph()
+//	g := graph.NewStateGraph[map[string]any]()
 //
 //	// Add nodes
 //	g.AddNode("process", func(ctx context.Context, state map[string]any) (map[string]any, error) {

--- a/docs/EXAMPLES_FIX_SUMMARY.md
+++ b/docs/EXAMPLES_FIX_SUMMARY.md
@@ -134,14 +134,14 @@
 ### 何时使用NewStateGraph()
 ```go
 // 1. 使用简单状态（字符串、数字等）
-g := graph.NewStateGraph()
+g := graph.NewStateGraph[map[string]any]()
 
 // 2. 使用自定义结构体
 type MyState struct { ... }
-g := graph.NewStateGraph()
+g := graph.NewStateGraph[map[string]any]()
 
 // 3. 使用LangChain消息但作为状态本身
-g := graph.NewStateGraph() // 状态是 []llms.MessageContent
+g := graph.NewStateGraph[map[string]any]() // 状态是 []llms.MessageContent
 ```
 
 ### 何时使用NewMessageGraph()

--- a/docs/GENERIC.md
+++ b/docs/GENERIC.md
@@ -178,7 +178,7 @@ type ListenableStateGraphMap = ListenableStateGraph[map[string]any]
 
 ```go
 // 非泛型版本
-g := graph.NewStateGraph()
+g := graph.NewStateGraph[map[string]any]()
 
 // 泛型版本
 g := graph.NewStateGraph[MyState]()
@@ -580,7 +580,7 @@ type MyState struct {
 
 ```go
 // 之前
-g := graph.NewStateGraph()
+g := graph.NewStateGraph[map[string]any]()
 
 // 之后
 g := graph.NewStateGraph[MyState]()
@@ -641,7 +641,7 @@ result, _ := app.Invoke(ctx, MyState{Count: 0})
 ```go
 // ====== 迁移前：非泛型版本 ======
 func oldVersion() error {
-    g := graph.NewStateGraph()
+    g := graph.NewStateGraph[map[string]any]()
 
     g.AddNode("increment", "Increment", func(ctx context.Context, state any) (any, error) {
         s := state.(map[string]any)

--- a/docs/GENERIC/GENERIC_IMPLEMENTATION_STATUS.md
+++ b/docs/GENERIC/GENERIC_IMPLEMENTATION_STATUS.md
@@ -6,9 +6,9 @@
 
 ### 核心 Graph 组件
 
-1. **StateGraphTyped** (`graph/state_graph_typed.go`)
+1. **StateGraph** (`graph/state_graph.go`)
    - 泛型版本的状态图，提供编译时类型安全
-   - API：`NewStateGraphTyped[S]()`
+   - API：`NewStateGraph[S]()`
    - 支持所有原有功能：节点、边、条件边、重试策略等
 
 2. **StateRunnableTyped** (`graph/state_graph_typed.go`)
@@ -62,7 +62,7 @@ type MyState struct {
 }
 
 // 创建泛型图
-g := graph.NewStateGraphTyped[MyState]()
+g := graph.NewStateGraph[MyState]()
 
 // 添加类型安全的节点
 g.AddNode("increment", "Increment counter", func(ctx context.Context, state MyState) (MyState, error) {

--- a/docs/MESSAGEGRAPH_DELETION_SUMMARY.md
+++ b/docs/MESSAGEGRAPH_DELETION_SUMMARY.md
@@ -137,7 +137,7 @@ g := graph.NewMessageGraph()
 **不需要消息处理（其他应用）：**
 ```go
 // 使用NewStateGraph，不带schema
-g := graph.NewStateGraph()
+g := graph.NewStateGraph[map[string]any]()
 // 可以自己配置schema或不使用schema
 ```
 
@@ -148,7 +148,7 @@ g := graph.NewStateGraph()
 // 这些代码继续工作，无需任何更改
 g := graph.NewMessageGraph()           // 现在默认带schema
 g := graph.NewMessageGraphWithSchema()  // 仍然可用
-g := graph.NewStateGraph()              // 不带schema版本
+g := graph.NewStateGraph[map[string]any]()              // 不带schema版本
 
 var mg *graph.MessageGraph = ...        // 实际是StateGraph
 var r *graph.Runnable = ...             // 实际是StateRunnable

--- a/docs/RAG/architecture_recommendation.md
+++ b/docs/RAG/architecture_recommendation.md
@@ -103,7 +103,7 @@ agent := create_agent.NewAgent(llm, []Tool{
 ```go
 // 这是一个标准的 RAG 流程图
 func NewRAGGraph(llm LLM, engine rag.Engine) *graph.StateGraph {
-    workflow := graph.NewStateGraph()
+    workflow := graph.NewStateGraph[map[string]any]()
     
     workflow.AddNode("retrieve", rag.NewRetrievalNode(engine, ...))
     workflow.AddNode("generate", NewGenerationNode(llm, ...))

--- a/docs/REACTAGENT.md
+++ b/docs/REACTAGENT.md
@@ -561,7 +561,7 @@ While ReAct Agent uses simple message state, you can build on it:
 reactAgent, _ := prebuilt.CreateReactAgent(model, tools)
 
 // Wrap in custom graph with additional state
-customWorkflow := graph.NewStateGraph()
+customWorkflow := graph.NewStateGraph[map[string]any]()
 schema := graph.NewMapSchema()
 schema.RegisterReducer("messages", graph.AppendReducer)
 schema.RegisterReducer("metadata", graph.OverwriteReducer)

--- a/docs/REACTAGENT_CN.md
+++ b/docs/REACTAGENT_CN.md
@@ -561,7 +561,7 @@ result, err := agent.Invoke(ctx, initialState)
 reactAgent, _ := prebuilt.CreateReactAgent(model, tools)
 
 // 使用额外状态包装在自定义图中
-customWorkflow := graph.NewStateGraph()
+customWorkflow := graph.NewStateGraph[map[string]any]()
 schema := graph.NewMapSchema()
 schema.RegisterReducer("messages", graph.AppendReducer)
 schema.RegisterReducer("metadata", graph.OverwriteReducer)

--- a/docs/STATE_MANAGEMENT.md
+++ b/docs/STATE_MANAGEMENT.md
@@ -658,7 +658,7 @@ type MyState struct {
     History []string
 }
 
-g := graph.NewStateGraphTyped[MyState]()
+g := graph.NewStateGraph[MyState]()
 
 g.AddNode("process", "process", func(ctx context.Context, state MyState) (MyState, error) {
     state.Output = strings.ToUpper(state.Input)

--- a/examples/basic_example/README.md
+++ b/examples/basic_example/README.md
@@ -55,7 +55,7 @@ The example will demonstrate each feature with clear output showing:
 
 ```go
 // Basic execution
-g := graph.NewStateGraph()
+g := graph.NewStateGraph[map[string]any]()
 g.AddNode("process", processingFunction)
 g.AddEdge("process", graph.END)
 

--- a/examples/generic_state_graph/README.md
+++ b/examples/generic_state_graph/README.md
@@ -24,7 +24,7 @@ Demonstrates basic usage with a workflow that checks user eligibility:
 - Direct access to state fields
 
 ```go
-g := graph.NewStateGraphTyped[WorkflowState]()
+g := graph.NewStateGraph[WorkflowState]()
 
 g.AddNode("check_age", "Check age", func(ctx context.Context, state WorkflowState) (WorkflowState, error) {
     state.IsAdult = state.Request.Age >= 18  // Type-safe!
@@ -124,7 +124,7 @@ Final State:
 ### Non-Generic (Old Way)
 
 ```go
-g := graph.NewStateGraph()
+g := graph.NewStateGraph[map[string]any]()
 
 g.AddNode("process", "desc", func(ctx context.Context, state any) (any, error) {
     s := state.(WorkflowState)  // Type assertion required ❌
@@ -139,7 +139,7 @@ finalState := result.(WorkflowState)  // Another type assertion ❌
 ### Generic (New Way)
 
 ```go
-g := graph.NewStateGraphTyped[WorkflowState]()
+g := graph.NewStateGraph[WorkflowState]()
 
 g.AddNode("process", "desc", func(ctx context.Context, state WorkflowState) (WorkflowState, error) {
     state.Count++  // Direct access ✅
@@ -166,7 +166,7 @@ type WorkflowState struct {
 ### Creating a Generic Graph
 
 ```go
-g := graph.NewStateGraphTyped[YourStateType]()
+g := graph.NewStateGraph[YourStateType]()
 ```
 
 ### Adding Typed Nodes
@@ -227,10 +227,10 @@ Migrating is straightforward:
 1. **Change constructor:**
    ```go
    // Before
-   g := graph.NewStateGraph()
+   g := graph.NewStateGraph[map[string]any]()
 
    // After
-   g := graph.NewStateGraphTyped[MyState]()
+   g := graph.NewStateGraph[MyState]()
    ```
 
 2. **Update node functions:**

--- a/examples/generic_state_graph/README_CN.md
+++ b/examples/generic_state_graph/README_CN.md
@@ -21,7 +21,7 @@
 展示了检查用户资格的基本用法：
 
 ```go
-g := graph.NewStateGraphTyped[WorkflowState]()
+g := graph.NewStateGraph[WorkflowState]()
 
 g.AddNode("check_age", "检查年龄", func(ctx context.Context, state WorkflowState) (WorkflowState, error) {
     state.IsAdult = state.Request.Age >= 18  // 类型安全！
@@ -71,7 +71,7 @@ go run main.go
 ### 非泛型（旧方式）
 
 ```go
-g := graph.NewStateGraph()
+g := graph.NewStateGraph[map[string]any]()
 
 g.AddNode("process", "desc", func(ctx context.Context, state any) (any, error) {
     s := state.(WorkflowState)  // 需要类型断言 ❌
@@ -86,7 +86,7 @@ finalState := result.(WorkflowState)  // 又一次类型断言 ❌
 ### 泛型（新方式）
 
 ```go
-g := graph.NewStateGraphTyped[WorkflowState]()
+g := graph.NewStateGraph[WorkflowState]()
 
 g.AddNode("process", "desc", func(ctx context.Context, state WorkflowState) (WorkflowState, error) {
     state.Count++  // 直接访问 ✅
@@ -117,10 +117,10 @@ finalState, _ := app.Invoke(ctx, initialState)  // 类型安全的结果 ✅
 1. **更改构造函数：**
    ```go
    // 之前
-   g := graph.NewStateGraph()
+   g := graph.NewStateGraph[map[string]any]()
 
    // 之后
-   g := graph.NewStateGraphTyped[MyState]()
+   g := graph.NewStateGraph[MyState]()
    ```
 
 2. **更新节点函数：**

--- a/examples/generic_state_graph_react_agent/README.md
+++ b/examples/generic_state_graph_react_agent/README.md
@@ -24,7 +24,7 @@ Demonstrates basic usage with a workflow that checks user eligibility:
 - Direct access to state fields
 
 ```go
-g := graph.NewStateGraphTyped[WorkflowState]()
+g := graph.NewStateGraph[WorkflowState]()
 
 g.AddNode("check_age", "Check age", func(ctx context.Context, state WorkflowState) (WorkflowState, error) {
     state.IsAdult = state.Request.Age >= 18  // Type-safe!
@@ -124,7 +124,7 @@ Final State:
 ### Non-Generic (Old Way)
 
 ```go
-g := graph.NewStateGraph()
+g := graph.NewStateGraph[map[string]any]()
 
 g.AddNode("process", "desc", func(ctx context.Context, state any) (any, error) {
     s := state.(WorkflowState)  // Type assertion required ❌
@@ -139,7 +139,7 @@ finalState := result.(WorkflowState)  // Another type assertion ❌
 ### Generic (New Way)
 
 ```go
-g := graph.NewStateGraphTyped[WorkflowState]()
+g := graph.NewStateGraph[WorkflowState]()
 
 g.AddNode("process", "desc", func(ctx context.Context, state WorkflowState) (WorkflowState, error) {
     state.Count++  // Direct access ✅
@@ -166,7 +166,7 @@ type WorkflowState struct {
 ### Creating a Generic Graph
 
 ```go
-g := graph.NewStateGraphTyped[YourStateType]()
+g := graph.NewStateGraph[YourStateType]()
 ```
 
 ### Adding Typed Nodes
@@ -227,10 +227,10 @@ Migrating is straightforward:
 1. **Change constructor:**
    ```go
    // Before
-   g := graph.NewStateGraph()
+   g := graph.NewStateGraph[map[string]any]()
 
    // After
-   g := graph.NewStateGraphTyped[MyState]()
+   g := graph.NewStateGraph[MyState]()
    ```
 
 2. **Update node functions:**

--- a/examples/generic_state_graph_react_agent/README_CN.md
+++ b/examples/generic_state_graph_react_agent/README_CN.md
@@ -21,7 +21,7 @@
 展示了检查用户资格的基本用法：
 
 ```go
-g := graph.NewStateGraphTyped[WorkflowState]()
+g := graph.NewStateGraph[WorkflowState]()
 
 g.AddNode("check_age", "检查年龄", func(ctx context.Context, state WorkflowState) (WorkflowState, error) {
     state.IsAdult = state.Request.Age >= 18  // 类型安全！
@@ -71,7 +71,7 @@ go run main.go
 ### 非泛型（旧方式）
 
 ```go
-g := graph.NewStateGraph()
+g := graph.NewStateGraph[map[string]any]()
 
 g.AddNode("process", "desc", func(ctx context.Context, state any) (any, error) {
     s := state.(WorkflowState)  // 需要类型断言 ❌
@@ -86,7 +86,7 @@ finalState := result.(WorkflowState)  // 又一次类型断言 ❌
 ### 泛型（新方式）
 
 ```go
-g := graph.NewStateGraphTyped[WorkflowState]()
+g := graph.NewStateGraph[WorkflowState]()
 
 g.AddNode("process", "desc", func(ctx context.Context, state WorkflowState) (WorkflowState, error) {
     state.Count++  // 直接访问 ✅
@@ -117,10 +117,10 @@ finalState, _ := app.Invoke(ctx, initialState)  // 类型安全的结果 ✅
 1. **更改构造函数：**
    ```go
    // 之前
-   g := graph.NewStateGraph()
+   g := graph.NewStateGraph[map[string]any]()
 
    // 之后
-   g := graph.NewStateGraphTyped[MyState]()
+   g := graph.NewStateGraph[MyState]()
    ```
 
 2. **更新节点函数：**

--- a/examples/logger/README.md
+++ b/examples/logger/README.md
@@ -168,7 +168,7 @@ func main() {
     setupLogging()
 
     // Graph execution will now use golog
-    g := graph.NewStateGraph()
+    g := graph.NewStateGraph[map[string]any]()
     // ... build graph
 }
 ```

--- a/examples/logger/README_CN.md
+++ b/examples/logger/README_CN.md
@@ -168,7 +168,7 @@ func main() {
     setupLogging()
 
     // 图执行现在将使用 golog
-    g := graph.NewStateGraph()
+    g := graph.NewStateGraph[map[string]any]()
     // ... 构建图
 }
 ```

--- a/examples/mental_loop/README.md
+++ b/examples/mental_loop/README.md
@@ -68,7 +68,7 @@ The market simulator provides:
 ## Workflow
 
 ```go
-workflow := graph.NewStateGraph()
+workflow := graph.NewStateGraph[map[string]any]()
 
 // Add nodes in sequence
 workflow.AddNode("analyst", AnalystNode)

--- a/examples/mental_loop/README_CN.md
+++ b/examples/mental_loop/README_CN.md
@@ -69,7 +69,7 @@ Mental Loop 模式实现了一个深思熟虑的决策过程：
 ## 工作流程
 
 ```go
-workflow := graph.NewStateGraph()
+workflow := graph.NewStateGraph[map[string]any]()
 
 // 按顺序添加节点
 workflow.AddNode("analyst", "analyst", AnalystNode)

--- a/graph/doc.go
+++ b/graph/doc.go
@@ -34,7 +34,7 @@
 //
 // Basic State Graph
 //
-//	g := graph.NewStateGraph()
+//	g := graph.NewStateGraph[map[string]any]()
 //
 //	// Add nodes
 //	g.AddNode("process", "Process node", func(ctx context.Context, state any) (any, error) {

--- a/log/doc.go
+++ b/log/doc.go
@@ -77,7 +77,7 @@
 //
 //	logger := log.NewDefaultLogger(log.LogLevelInfo)
 //
-//	g := graph.NewStateGraph()
+//	g := graph.NewStateGraph[map[string]any]()
 //	// ... configure graph ...
 //
 //	// Add a logging listener

--- a/ptc/doc.go
+++ b/ptc/doc.go
@@ -202,7 +202,7 @@
 //
 // The PTC agent integrates seamlessly with LangGraph:
 //
-//	g := graph.NewStateGraph()
+//	g := graph.NewStateGraph[map[string]any]()
 //
 //	// Add PTC node
 //	ptcNode := ptc.NewPTCToolNode(ptc.LanguagePython, tools)

--- a/store/doc.go
+++ b/store/doc.go
@@ -117,7 +117,7 @@
 // ## Basic Checkpointing
 //
 //	// Create a graph
-//	g := graph.NewStateGraph()
+//	g := graph.NewStateGraph[map[string]any]()
 //	// ... configure graph ...
 //
 //	// Choose and configure a store
@@ -251,7 +251,7 @@
 //	)
 //
 //	// With custom graphs
-//	g := graph.NewStateGraph()
+//	g := graph.NewStateGraph[map[string]any]()
 //	g.WithCheckpointing(graph.CheckpointConfig{
 //	    Store: store,
 //	})

--- a/store/postgres/doc.go
+++ b/store/postgres/doc.go
@@ -39,7 +39,7 @@
 //	}
 //
 //	// Use with a graph
-//	g := graph.NewStateGraph()
+//	g := graph.NewStateGraph[map[string]any]()
 //	// ... configure graph ...
 //
 //	// Enable checkpointing

--- a/store/redis/doc.go
+++ b/store/redis/doc.go
@@ -32,7 +32,7 @@
 //	})
 //
 //	// Use with a graph
-//	g := graph.NewStateGraph()
+//	g := graph.NewStateGraph[map[string]any]()
 //	// ... configure graph ...
 //
 //	// Enable checkpointing

--- a/store/sqlite/doc.go
+++ b/store/sqlite/doc.go
@@ -35,7 +35,7 @@
 //	defer store.Close()
 //
 //	// Use with a graph
-//	g := graph.NewStateGraph()
+//	g := graph.NewStateGraph[map[string]any]()
 //	// ... configure graph ...
 //
 //	// Enable checkpointing


### PR DESCRIPTION
This PR updates outdated usages of `graph.NewStateGraph` and removes reference to the `graph.NewStateGraphTyped` method that was first introduced in the STATEGRAPH RFC but appears to have not been developed.

No changes were made to the RFC. Suggest a comment is made on the RFC on what the exact outcome was.

RFC can be read here:
[RFC_GENERIC_STATEGRAPH](https://github.com/smallnest/langgraphgo/blob/master/docs/GENERIC/RFC_GENERIC_STATEGRAPH.md)


Fix: #98 