### PR TITLE
refactor(memory): isolate langchaingo shim into langchainadapter subpackage

### DIFF
--- a/docs/Memory/LANGCHAIN_MEMORY_INTEGRATION.md
+++ b/docs/Memory/LANGCHAIN_MEMORY_INTEGRATION.md
@@ -9,7 +9,14 @@ Memory is crucial for conversational AI applications. It allows the system to:
 - Maintain context across multiple turns
 - Personalize responses based on history
 
-We provide a `LangChainMemory` adapter that wraps LangChainGo's memory implementations, making them compatible with LangGraphGo's architecture.
+We provide a `LangChainMemory` adapter that wraps LangChainGo's memory implementations, making them compatible with LangGraphGo's architecture. The adapter lives in its own subpackage so the core `memory` package stays free of the `langchaingo` dependency:
+
+```go
+import (
+    langchainadapter "github.com/smallnest/langgraphgo/memory/langchainadapter"
+    langchainmemory "github.com/tmc/langchaingo/memory"
+)
+```
 
 ## Available Memory Types
 
@@ -19,8 +26,8 @@ The integration supports all standard LangChainGo memory types:
 Stores the entire conversation history. This is useful when you want the model to have access to everything that has been said.
 
 ```go
-mem := prebuilt.NewConversationBufferMemory(
-    memory.WithReturnMessages(true),
+mem := langchainadapter.NewConversationBufferMemory(
+    langchainmemory.WithReturnMessages(true),
 )
 ```
 
@@ -29,26 +36,16 @@ Keeps a sliding window of the most recent N conversation turns. This is useful f
 
 ```go
 // Keep only the last 5 turns
-mem := prebuilt.NewConversationWindowBufferMemory(5,
-    memory.WithReturnMessages(true),
+mem := langchainadapter.NewConversationWindowBufferMemory(5,
+    langchainmemory.WithReturnMessages(true),
 )
 ```
 
-### 3. ConversationTokenBuffer
-Maintains conversation history within a specific token limit. This is ideal for managing costs and staying within LLM context window limits.
-
-```go
-// Keep history within 1000 tokens
-mem := prebuilt.NewConversationTokenBufferMemory(llm, 1000,
-    memory.WithReturnMessages(true),
-)
-```
-
-### 4. ChatMessageHistory
+### 3. ChatMessageHistory
 Provides direct access to the underlying message history storage, allowing you to manually add or retrieve messages.
 
 ```go
-history := prebuilt.NewChatMessageHistory()
+history := langchainadapter.NewChatMessageHistory()
 history.AddUserMessage(ctx, "Hello")
 history.AddAIMessage(ctx, "Hi there")
 ```
@@ -108,11 +105,11 @@ func chatNode(ctx context.Context, state *State) (*State, error) {
 You can customize the keys used for input, output, and memory variables if your application requires specific naming conventions.
 
 ```go
-mem := prebuilt.NewConversationBufferMemory(
-    memory.WithInputKey("user_query"),      // Default: "input"
-    memory.WithOutputKey("bot_response"),   // Default: "output"
-    memory.WithMemoryKey("chat_log"),       // Default: "history"
-    memory.WithReturnMessages(true),
+mem := langchainadapter.NewConversationBufferMemory(
+    langchainmemory.WithInputKey("user_query"),      // Default: "input"
+    langchainmemory.WithOutputKey("bot_response"),   // Default: "output"
+    langchainmemory.WithMemoryKey("chat_log"),       // Default: "history"
+    langchainmemory.WithReturnMessages(true),
 )
 ```
 
@@ -120,9 +117,9 @@ mem := prebuilt.NewConversationBufferMemory(
 You can also customize the prefixes used for messages when they are returned as a string (i.e., `WithReturnMessages(false)`).
 
 ```go
-mem := prebuilt.NewConversationBufferMemory(
-    memory.WithHumanPrefix("User"),
-    memory.WithAIPrefix("Assistant"),
+mem := langchainadapter.NewConversationBufferMemory(
+    langchainmemory.WithHumanPrefix("User"),
+    langchainmemory.WithAIPrefix("Assistant"),
 )
 ```
 

--- a/docs/Memory/LANGCHAIN_MEMORY_INTEGRATION_CN.md
+++ b/docs/Memory/LANGCHAIN_MEMORY_INTEGRATION_CN.md
@@ -9,7 +9,14 @@ Memory（记忆）对于对话式 AI 应用至关重要。它允许系统：
 - 在多轮对话中维护上下文
 - 基于历史记录提供个性化响应
 
-我们提供了一个 `LangChainMemory` 适配器，它封装了 LangChainGo 的 memory 实现，使其与 LangGraphGo 的架构兼容。
+我们提供了一个 `LangChainMemory` 适配器，它封装了 LangChainGo 的 memory 实现，使其与 LangGraphGo 的架构兼容。该适配器位于独立子包中，因此核心 `memory` 包不再依赖 `langchaingo`：
+
+```go
+import (
+    langchainadapter "github.com/smallnest/langgraphgo/memory/langchainadapter"
+    langchainmemory "github.com/tmc/langchaingo/memory"
+)
+```
 
 ## 可用的 Memory 类型
 
@@ -19,8 +26,8 @@ Memory（记忆）对于对话式 AI 应用至关重要。它允许系统：
 存储完整的对话历史记录。当您希望模型能够访问所有已说内容时，这非常有用。
 
 ```go
-mem := prebuilt.NewConversationBufferMemory(
-    memory.WithReturnMessages(true),
+mem := langchainadapter.NewConversationBufferMemory(
+    langchainmemory.WithReturnMessages(true),
 )
 ```
 
@@ -29,26 +36,16 @@ mem := prebuilt.NewConversationBufferMemory(
 
 ```go
 // 仅保留最后 5 轮
-mem := prebuilt.NewConversationWindowBufferMemory(5,
-    memory.WithReturnMessages(true),
+mem := langchainadapter.NewConversationWindowBufferMemory(5,
+    langchainmemory.WithReturnMessages(true),
 )
 ```
 
-### 3. ConversationTokenBuffer (对话 Token 缓冲)
-在特定的 Token 限制内维护对话历史。这对于管理成本和保持在 LLM 上下文窗口限制内非常理想。
-
-```go
-// 将历史记录保持在 1000 个 token 以内
-mem := prebuilt.NewConversationTokenBufferMemory(llm, 1000,
-    memory.WithReturnMessages(true),
-)
-```
-
-### 4. ChatMessageHistory (聊天消息历史)
+### 3. ChatMessageHistory (聊天消息历史)
 提供对底层消息历史存储的直接访问，允许您手动添加或检索消息。
 
 ```go
-history := prebuilt.NewChatMessageHistory()
+history := langchainadapter.NewChatMessageHistory()
 history.AddUserMessage(ctx, "你好")
 history.AddAIMessage(ctx, "你好！")
 ```
@@ -108,11 +105,11 @@ func chatNode(ctx context.Context, state *State) (*State, error) {
 如果您的应用程序需要特定的命名约定，您可以自定义用于输入、输出和 memory 变量的键。
 
 ```go
-mem := prebuilt.NewConversationBufferMemory(
-    memory.WithInputKey("user_query"),      // 默认: "input"
-    memory.WithOutputKey("bot_response"),   // 默认: "output"
-    memory.WithMemoryKey("chat_log"),       // 默认: "history"
-    memory.WithReturnMessages(true),
+mem := langchainadapter.NewConversationBufferMemory(
+    langchainmemory.WithInputKey("user_query"),      // 默认: "input"
+    langchainmemory.WithOutputKey("bot_response"),   // 默认: "output"
+    langchainmemory.WithMemoryKey("chat_log"),       // 默认: "history"
+    langchainmemory.WithReturnMessages(true),
 )
 ```
 
@@ -120,9 +117,9 @@ mem := prebuilt.NewConversationBufferMemory(
 当消息作为字符串返回时（即 `WithReturnMessages(false)`），您还可以自定义用于消息的前缀。
 
 ```go
-mem := prebuilt.NewConversationBufferMemory(
-    memory.WithHumanPrefix("用户"),
-    memory.WithAIPrefix("助手"),
+mem := langchainadapter.NewConversationBufferMemory(
+    langchainmemory.WithHumanPrefix("用户"),
+    langchainmemory.WithAIPrefix("助手"),
 )
 ```
 

--- a/docs/issue#0100.html
+++ b/docs/issue#0100.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0100</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/langgraphgo/issues/100">#100</a> &mdash; 精简: 移除/隔离 memory 中的 langchaingo 兼容垫片 &mdash; 2026-07-08</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> New subpackage <code>memory/langchainadapter</code> as the sole langchaingo importer</h3>
+      <p><strong>Ambiguity:</strong> The issue said "迁移到独立子包(如 memory/langchainadapter)" but did not name the package or specify what moves.</p>
+      <p><strong>Choice:</strong> Moved the entire adapter file (types <code>ChatMemory</code>, <code>LangChainMemory</code>, <code>ChatMessageHistory</code> and their methods) verbatim into <code>package langchainadapter</code> via <code>git mv</code>, preserving history.</p>
+      <p><strong>Rationale:</strong> <code>ChatMemory</code> is referenced only by the adapter itself, so nothing had to stay in the core package. <code>go list -deps ./memory</code> now reports zero <code>tmc/langchaingo</code> dependencies — the stated goal.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Examples repointed to the adapter, not rewritten to native Buffer/SlidingWindow</h3>
+      <p><strong>Spec:</strong> Suggestion #3 said "更新 examples 使用原生 Buffer/SlidingWindow 构造函数".</p>
+      <p><strong>Implemented:</strong> <code>examples/memory_basic</code> and <code>examples/memory_chatbot</code> keep using the langchain adapter, only switching their import to the new <code>langchainadapter</code> subpackage.</p>
+      <p><strong>Why:</strong> The native <code>BufferMemory</code> API is structurally different (message-object <code>AddMessage</code>/<code>GetContext</code> vs the adapter's map-based <code>SaveContext</code>/<code>LoadMemoryVariables</code> and langchain options like <code>WithMemoryKey</code>/<code>WithReturnMessages</code>). These examples exist specifically to demonstrate the langchain-compatible surface, so rewriting them would delete that demonstration rather than update it. The dependency-isolation goal is fully met regardless of which constructor the examples call.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Fixed the affected docs in place instead of a full rewrite</h3>
+      <p><strong>Alternatives:</strong> (a) leave docs untouched; (b) fully rewrite the LangChain integration docs; (c) minimally correct only what this change broke.</p>
+      <p><strong>Chosen (c):</strong> Removed the <code>ConversationTokenBuffer</code> section (its constructor was deleted), corrected the long-stale <code>prebuilt.</code> prefix to <code>langchainadapter.</code>, and added an import snippet — in both EN and CN docs.</p>
+      <p><strong>Why:</strong> (a) would ship docs referencing a deleted symbol; (b) is a separate docs task beyond this issue's scope. (c) keeps the shipped tree self-consistent with minimal blast radius.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Release-note the API break</h3>
+      <p><strong>Assumption:</strong> Deleting <code>NewLangChainMemory</code> / <code>NewConversationTokenBufferMemory</code> (both zero internal references) and relocating the surviving constructors to <code>memory/langchainadapter</code> is an acceptable break.</p>
+      <p><strong>Verify:</strong> External callers importing these from <code>memory</code> must update their import path; the token-buffer helper has no drop-in replacement in this repo. The issue itself flagged this needs a release note.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/examples/memory_basic/main.go
+++ b/examples/memory_basic/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/smallnest/langgraphgo/llmtypes"
-	"github.com/smallnest/langgraphgo/memory"
+	langchainadapter "github.com/smallnest/langgraphgo/memory/langchainadapter"
 	langchainmemory "github.com/tmc/langchaingo/memory"
 )
 
@@ -37,7 +37,7 @@ func main() {
 // basicMemoryExample demonstrates basic conversation buffer usage
 func basicMemoryExample(ctx context.Context) {
 	// Create a conversation buffer memory with return messages enabled
-	mem := memory.NewConversationBufferMemory(
+	mem := langchainadapter.NewConversationBufferMemory(
 		langchainmemory.WithReturnMessages(true),
 	)
 
@@ -81,7 +81,7 @@ func basicMemoryExample(ctx context.Context) {
 // windowMemoryExample demonstrates conversation window buffer
 func windowMemoryExample(ctx context.Context) {
 	// Create a window buffer that keeps only the last 2 conversation turns
-	mem := memory.NewConversationWindowBufferMemory(2,
+	mem := langchainadapter.NewConversationWindowBufferMemory(2,
 		langchainmemory.WithReturnMessages(true),
 	)
 
@@ -124,7 +124,7 @@ func windowMemoryExample(ctx context.Context) {
 // chatHistoryExample demonstrates direct chat message history usage
 func chatHistoryExample(ctx context.Context) {
 	// Create a chat message history
-	history := memory.NewChatMessageHistory()
+	history := langchainadapter.NewChatMessageHistory()
 
 	// Add different types of messages
 	err := history.AddMessage(ctx, llmtypes.SystemChatMessage{
@@ -159,7 +159,7 @@ func chatHistoryExample(ctx context.Context) {
 // customKeysExample demonstrates using custom input/output/memory keys
 func customKeysExample(ctx context.Context) {
 	// Create memory with custom keys
-	mem := memory.NewConversationBufferMemory(
+	mem := langchainadapter.NewConversationBufferMemory(
 		langchainmemory.WithInputKey("user_input"),
 		langchainmemory.WithOutputKey("ai_response"),
 		langchainmemory.WithMemoryKey("chat_history"),
@@ -204,7 +204,7 @@ func memoryIntegrationPattern(ctx context.Context) {
 	fmt.Println()
 
 	// Create memory
-	mem := memory.NewConversationBufferMemory(
+	mem := langchainadapter.NewConversationBufferMemory(
 		langchainmemory.WithReturnMessages(true),
 	)
 

--- a/examples/memory_chatbot/main.go
+++ b/examples/memory_chatbot/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/smallnest/langgraphgo/llmtypes"
-	"github.com/smallnest/langgraphgo/memory"
+	langchainadapter "github.com/smallnest/langgraphgo/memory/langchainadapter"
 	langchainmemory "github.com/tmc/langchaingo/memory"
 )
 
@@ -31,18 +31,18 @@ func main() {
 // runChatbotSimulation simulates a chatbot conversation with memory
 func runChatbotSimulation(ctx context.Context, memoryType string, windowSize int) {
 	// Create memory based on type
-	var mem *memory.LangChainMemory
+	var mem *langchainadapter.LangChainMemory
 	switch memoryType {
 	case "buffer":
-		mem = memory.NewConversationBufferMemory(
+		mem = langchainadapter.NewConversationBufferMemory(
 			langchainmemory.WithReturnMessages(true),
 		)
 	case "window":
-		mem = memory.NewConversationWindowBufferMemory(windowSize,
+		mem = langchainadapter.NewConversationWindowBufferMemory(windowSize,
 			langchainmemory.WithReturnMessages(true),
 		)
 	default:
-		mem = memory.NewConversationBufferMemory(
+		mem = langchainadapter.NewConversationBufferMemory(
 			langchainmemory.WithReturnMessages(true),
 		)
 	}
@@ -124,14 +124,14 @@ func runChatbotSimulation(ctx context.Context, memoryType string, windowSize int
 // demonstrateMemoryPersistence shows how memory persists across interactions
 func demonstrateMemoryPersistence(ctx context.Context) {
 	// Create a custom chat history
-	chatHistory := memory.NewChatMessageHistory()
+	chatHistory := langchainadapter.NewChatMessageHistory()
 
 	// Add initial messages
 	chatHistory.AddUserMessage(ctx, "I'm learning about LangGraph")
 	chatHistory.AddAIMessage(ctx, "That's great! LangGraph is a powerful framework for building stateful, multi-actor applications.")
 
 	// Create memory with the custom chat history
-	mem := memory.NewConversationBufferMemory(
+	mem := langchainadapter.NewConversationBufferMemory(
 		langchainmemory.WithChatHistory(chatHistory.GetHistory()),
 		langchainmemory.WithReturnMessages(true),
 	)

--- a/memory/doc.go
+++ b/memory/doc.go
@@ -159,10 +159,12 @@
 //
 // # Integration with LangChain
 //
-// The package includes adapters for LangChain compatibility:
+// LangChain-compatible memory adapters live in the memory/langchainadapter
+// subpackage, which is the only place that imports github.com/tmc/langchaingo:
 //
-//	// Convert to LangChain ChatMemory
-//	langchainMem := memory.NewLangchainAdapter(mem)
+//	import "github.com/smallnest/langgraphgo/memory/langchainadapter"
+//
+//	mem := langchainadapter.NewConversationBufferMemory()
 //
 // # Compression Strategies
 //

--- a/memory/langchainadapter/adapter.go
+++ b/memory/langchainadapter/adapter.go
@@ -1,4 +1,8 @@
-package memory
+// Package langchainadapter bridges langchaingo's memory implementations to the
+// framework's own message types. It is the sole importer of
+// github.com/tmc/langchaingo in the memory tree, keeping that dependency out of
+// the core memory package.
+package langchainadapter
 
 import (
 	"context"
@@ -26,14 +30,6 @@ type LangChainMemory struct {
 	buffer schema.Memory
 }
 
-// NewLangChainMemory creates a new adapter for langchaingo memory
-// Supports ConversationBuffer, ConversationWindowBuffer, ConversationTokenBuffer, etc.
-func NewLangChainMemory(buffer schema.Memory) *LangChainMemory {
-	return &LangChainMemory{
-		buffer: buffer,
-	}
-}
-
 // NewConversationBufferMemory creates a new conversation buffer memory with default settings
 func NewConversationBufferMemory(options ...langchainmemory.ConversationBufferOption) *LangChainMemory {
 	return &LangChainMemory{
@@ -46,14 +42,6 @@ func NewConversationBufferMemory(options ...langchainmemory.ConversationBufferOp
 func NewConversationWindowBufferMemory(windowSize int, options ...langchainmemory.ConversationBufferOption) *LangChainMemory {
 	return &LangChainMemory{
 		buffer: langchainmemory.NewConversationWindowBuffer(windowSize, options...),
-	}
-}
-
-// NewConversationTokenBufferMemory creates a new conversation token buffer memory
-// that keeps conversation history within a token limit
-func NewConversationTokenBufferMemory(llm llmtypes.Model, maxTokenLimit int, options ...langchainmemory.ConversationBufferOption) *LangChainMemory {
-	return &LangChainMemory{
-		buffer: langchainmemory.NewConversationTokenBuffer(llmtypes.ToLangchain(llm), maxTokenLimit, options...),
 	}
 }
 

--- a/memory/langchainadapter/adapter_test.go
+++ b/memory/langchainadapter/adapter_test.go
@@ -1,4 +1,4 @@
-package memory
+package langchainadapter
 
 import (
 	"context"


### PR DESCRIPTION
## Summary
- Move the langchain-compatible memory adapter into a new `memory/langchainadapter` subpackage — now the sole importer of `github.com/tmc/langchaingo` in the memory tree.
- Core `memory` package now has **zero** langchaingo dependencies (verified via `go list -deps ./memory`).
- Delete two zero-reference constructors: `NewLangChainMemory` and `NewConversationTokenBufferMemory`.
- Repoint `memory_basic` / `memory_chatbot` examples to the subpackage.
- Fix stale prefixes and drop the `ConversationTokenBuffer` section in the EN/CN LangChain memory integration docs.

## API break (needs release note)
External callers importing `NewConversationBufferMemory` / `NewConversationWindowBufferMemory` / `NewChatMessageHistory` from `memory` must switch to `memory/langchainadapter`. `NewLangChainMemory` and `NewConversationTokenBufferMemory` are removed (no drop-in replacement for the token-buffer helper).

## Test plan
- [x] `go build ./...`
- [x] `go test ./memory/...` (green)
- [x] `go vet ./memory/...`
- [x] `cd examples && go build ./memory_basic/ ./memory_chatbot/`
- [x] `go list -deps ./memory | grep tmc/langchaingo` → 0

Closes #100