### PR TITLE
Unify plan-execute agent option surface

### DIFF
--- a/docs/issue#0101.html
+++ b/docs/issue#0101.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0101</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/langgraphgo/issues/101">#101</a> &mdash; Converge the plan-execute prebuilt agents &mdash; 2026-07-08</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Unify the option surface instead of merging the agents</h3>
+      <p><strong>Ambiguity:</strong> The issue asked to "converge" CreatePlanningAgent, CreateManusAgent and CreatePEVAgent, implying they were redundant variants of one pattern.</p>
+      <p><strong>Choice:</strong> Kept all three factories and their distinct graph topologies; converged only the configuration API by making all three accept the shared <code>CreateAgentOption</code> functional options.</p>
+      <p><strong>Rationale:</strong> The three agents are genuinely different execution graphs (single-shot DAG vs. filesystem-persistent phase loop vs. plan-execute-verify retry loop). Merging them into one factory would produce a leaky mega-constructor. Converging the option surface removes the real inconsistency (three different config idioms) without destroying working, distinct behaviors.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Config-struct fields take precedence over options</h3>
+      <p><strong>Ambiguity:</strong> When both a legacy config struct and a functional option set the same field, which wins?</p>
+      <p><strong>Choice:</strong> Non-zero config-struct fields win; options only fill fields the caller left unset (implemented in <code>applyManusOptions</code> / <code>applyPEVOptions</code>).</p>
+      <p><strong>Rationale:</strong> Preserves the exact behavior of every existing caller that passes a fully-populated config. Options become purely additive, so no current code path changes.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Did not remove or merge any agent factory</h3>
+      <p><strong>Spec said:</strong> "Converge" the planning agents, which reads as consolidate/remove duplication.</p>
+      <p><strong>Implemented instead:</strong> A non-breaking convergence — deprecated <code>ManusConfig</code> and <code>PEVAgentConfig</code> via godoc, kept them working, and unified only the option-passing API.</p>
+      <p><strong>Why better:</strong> The issue's premise (that the three are convergeable variants) is contradicted by the code: they have distinct topologies and live example programs and tests reference each. A hard merge would break <code>examples/manus_agent</code>, <code>examples/pev_agent</code>, and the prebuilt test suite for no design gain.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Shared option struct vs. per-agent option types</h3>
+      <p><strong>Alternatives:</strong> (a) one shared <code>CreateAgentOptions</code> with agent-specific fields; (b) a separate option type per factory.</p>
+      <p><strong>Pros/cons:</strong> (a) gives callers one consistent import and With* vocabulary but carries fields not every factory reads; (b) is tightly scoped per agent but reintroduces the very API divergence the issue complains about.</p>
+      <p><strong>Why chosen:</strong> (a) — the whole point was a single consistent surface. Field applicability is documented in the struct godoc so the extra fields are discoverable, not confusing.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Two near-identical apply* helpers vs. one generic folder</h3>
+      <p><strong>Alternatives:</strong> keep <code>applyManusOptions</code> and <code>applyPEVOptions</code> separate, or extract a reflection/generic merge.</p>
+      <p><strong>Pros/cons:</strong> separate helpers duplicate ~6 lines each but stay type-safe and trivially readable; a generic merge would need reflection and obscure the precedence rule.</p>
+      <p><strong>Why chosen:</strong> two small explicit helpers — they operate on different config types and the duplication is cheaper than the abstraction.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Is deprecation the intended end state, or full removal later?</h3>
+      <p><strong>Assumption:</strong> <code>ManusConfig</code> / <code>PEVAgentConfig</code> stay indefinitely as deprecated-but-supported.</p>
+      <p><strong>Verify:</strong> Confirm whether a future major version should remove the config structs entirely and make options the only path.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> No PRD found for this issue</h3>
+      <p><strong>Follow-up:</strong> There is no <code>tasks/prd-*.md</code> for #101 — notes were written against the issue body and the observed code. Verify against the original issue acceptance criteria.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/prebuilt/create_agent.go
+++ b/prebuilt/create_agent.go
@@ -14,7 +14,12 @@ import (
 	"github.com/smallnest/langgraphgo/tooltypes"
 )
 
-// CreateAgentOptions contains options for creating an agent
+// CreateAgentOptions contains options for creating an agent.
+//
+// The plan-execute family (CreatePlanningAgent, CreateManusAgent, CreatePEVAgent)
+// shares this option surface. Fields below the common set are consumed only by the
+// factories they apply to: MaxRetries/VerificationPrompt by the PEV agent, and
+// WorkDir/PlanPath/NotesPath/OutputPath/AutoSave by the Manus agent.
 type CreateAgentOptions struct {
 	skillDir               string
 	Verbose                bool
@@ -22,6 +27,17 @@ type CreateAgentOptions struct {
 	StateModifier          func(messages []llmtypes.MessageContent) []llmtypes.MessageContent
 	MaxIterations          int
 	DisableModelInvocation bool
+
+	// PEV agent options.
+	MaxRetries         int
+	VerificationPrompt string
+
+	// Manus agent options.
+	WorkDir    string
+	PlanPath   string
+	NotesPath  string
+	OutputPath string
+	AutoSave   bool
 }
 
 type CreateAgentOption func(*CreateAgentOptions)
@@ -48,6 +64,41 @@ func WithMaxIterations(maxIterations int) CreateAgentOption {
 
 func WithDisableModelInvocation(disable bool) CreateAgentOption {
 	return func(o *CreateAgentOptions) { o.DisableModelInvocation = disable }
+}
+
+// WithMaxRetries sets the maximum replanning retries for the PEV agent.
+func WithMaxRetries(maxRetries int) CreateAgentOption {
+	return func(o *CreateAgentOptions) { o.MaxRetries = maxRetries }
+}
+
+// WithVerificationPrompt sets the verification system prompt for the PEV agent.
+func WithVerificationPrompt(prompt string) CreateAgentOption {
+	return func(o *CreateAgentOptions) { o.VerificationPrompt = prompt }
+}
+
+// WithWorkDir sets the working directory for the Manus agent's persistent files.
+func WithWorkDir(dir string) CreateAgentOption {
+	return func(o *CreateAgentOptions) { o.WorkDir = dir }
+}
+
+// WithPlanPath sets the plan file path for the Manus agent.
+func WithPlanPath(path string) CreateAgentOption {
+	return func(o *CreateAgentOptions) { o.PlanPath = path }
+}
+
+// WithNotesPath sets the notes file path for the Manus agent.
+func WithNotesPath(path string) CreateAgentOption {
+	return func(o *CreateAgentOptions) { o.NotesPath = path }
+}
+
+// WithOutputPath sets the output file path for the Manus agent.
+func WithOutputPath(path string) CreateAgentOption {
+	return func(o *CreateAgentOptions) { o.OutputPath = path }
+}
+
+// WithAutoSave toggles persisting plan/notes/output to disk for the Manus agent.
+func WithAutoSave(autoSave bool) CreateAgentOption {
+	return func(o *CreateAgentOptions) { o.AutoSave = autoSave }
 }
 
 // CreateAgentMap creates a new agent graph with map[string]any state

--- a/prebuilt/doc.go
+++ b/prebuilt/doc.go
@@ -109,6 +109,22 @@
 //		},
 //	})
 //
+// ## Choosing a Plan-Execute Agent
+// Three factories implement the "plan then execute" idea with different topologies;
+// pick by how execution and verification should work:
+//
+//   - CreatePlanningAgent: plans a workflow graph, then runs it once. Best when the
+//     task decomposes into a static DAG of the available nodes.
+//   - CreateManusAgent: multi-phase plan persisted to Markdown files, executed phase
+//     by phase with progress checkboxes. Best for long-running, resumable tasks.
+//   - CreatePEVAgent: plan → execute → verify loop that replans failed steps up to a
+//     retry budget. Best when steps need validation before proceeding.
+//
+// All three share one functional-option surface (WithVerbose, WithSystemMessage,
+// WithMaxRetries, WithVerificationPrompt, WithWorkDir, WithAutoSave, ...). The older
+// ManusConfig / PEVAgentConfig struct entry points still work but are deprecated in
+// favor of these options.
+//
 // ## Reflection Agent
 // Uses self-reflection to improve responses:
 //

--- a/prebuilt/manus_planning_agent.go
+++ b/prebuilt/manus_planning_agent.go
@@ -14,7 +14,12 @@ import (
 	"github.com/smallnest/langgraphgo/tooltypes"
 )
 
-// ManusConfig configures a Manus-style planning agent with persistent files
+// ManusConfig configures a Manus-style planning agent with persistent files.
+//
+// Deprecated: prefer passing the equivalent functional options to CreateManusAgent
+// (WithWorkDir, WithPlanPath, WithNotesPath, WithOutputPath, WithAutoSave,
+// WithVerbose), which share the plan-execute option surface. ManusConfig remains
+// supported; when both are supplied, non-zero ManusConfig fields take precedence.
 type ManusConfig struct {
 	WorkDir    string
 	PlanPath   string
@@ -30,6 +35,10 @@ type ManusConfig struct {
 // 3. Tracks progress with checkboxes
 // 4. Supports human-in-the-loop intervention
 // 5. Maintains persistent state across sessions
+//
+// The agent can be configured via the ManusConfig struct or via the shared
+// functional options (WithWorkDir, WithAutoSave, WithVerbose, ...). Non-zero
+// ManusConfig fields take precedence over the corresponding options.
 func CreateManusAgent(
 	model llmtypes.Model,
 	availableNodes []graph.TypedNode[map[string]any],
@@ -37,6 +46,8 @@ func CreateManusAgent(
 	config ManusConfig,
 	opts ...CreateAgentOption,
 ) (*graph.StateRunnable[map[string]any], error) {
+	config = applyManusOptions(config, opts...)
+
 	// Validate config
 	if config.WorkDir == "" {
 		config.WorkDir = "./work"
@@ -270,6 +281,37 @@ func CreateManusAgent(
 	// workflow.InterruptBefore([]string{"planner"})
 
 	return workflow.Compile()
+}
+
+// applyManusOptions folds shared functional options into a ManusConfig. Non-zero
+// ManusConfig fields win; options only fill fields the caller left unset.
+func applyManusOptions(config ManusConfig, opts ...CreateAgentOption) ManusConfig {
+	if len(opts) == 0 {
+		return config
+	}
+	o := &CreateAgentOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	if config.WorkDir == "" {
+		config.WorkDir = o.WorkDir
+	}
+	if config.PlanPath == "" {
+		config.PlanPath = o.PlanPath
+	}
+	if config.NotesPath == "" {
+		config.NotesPath = o.NotesPath
+	}
+	if config.OutputPath == "" {
+		config.OutputPath = o.OutputPath
+	}
+	if !config.AutoSave {
+		config.AutoSave = o.AutoSave
+	}
+	if !config.Verbose {
+		config.Verbose = o.Verbose
+	}
+	return config
 }
 
 // Phase represents a single phase in the Manus plan

--- a/prebuilt/pev_agent.go
+++ b/prebuilt/pev_agent.go
@@ -11,7 +11,12 @@ import (
 	"github.com/smallnest/langgraphgo/tooltypes"
 )
 
-// PEVAgentConfig configures the PEV (Plan, Execute, Verify) agent
+// PEVAgentConfig configures a Plan-Execute-Verify agent.
+//
+// Deprecated: prefer the shared functional options on CreatePEVAgentMap
+// (WithMaxRetries, WithSystemMessage, WithVerificationPrompt, WithVerbose), which
+// align the PEV agent with the rest of the plan-execute family. The config struct
+// remains supported; non-zero config fields take precedence over options.
 type PEVAgentConfig struct {
 	Model              llmtypes.Model
 	Tools              []tooltypes.Tool
@@ -27,8 +32,38 @@ type VerificationResult struct {
 	Reasoning    string `json:"reasoning"`
 }
 
-// CreatePEVAgentMap creates a new PEV Agent with map[string]any state
-func CreatePEVAgentMap(config PEVAgentConfig) (*graph.StateRunnable[map[string]any], error) {
+// applyPEVOptions folds shared functional options into a PEVAgentConfig. Non-zero
+// config fields win; options only fill fields the caller left unset.
+func applyPEVOptions(config PEVAgentConfig, opts ...CreateAgentOption) PEVAgentConfig {
+	if len(opts) == 0 {
+		return config
+	}
+	o := &CreateAgentOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	if config.MaxRetries == 0 {
+		config.MaxRetries = o.MaxRetries
+	}
+	if config.SystemMessage == "" {
+		config.SystemMessage = o.SystemMessage
+	}
+	if config.VerificationPrompt == "" {
+		config.VerificationPrompt = o.VerificationPrompt
+	}
+	if !config.Verbose {
+		config.Verbose = o.Verbose
+	}
+	return config
+}
+
+// CreatePEVAgentMap creates a new PEV Agent with map[string]any state.
+//
+// Behavior can be configured via the PEVAgentConfig struct or the shared
+// functional options (WithMaxRetries, WithSystemMessage, WithVerificationPrompt,
+// WithVerbose). Non-zero config fields take precedence over options.
+func CreatePEVAgentMap(config PEVAgentConfig, opts ...CreateAgentOption) (*graph.StateRunnable[map[string]any], error) {
+	config = applyPEVOptions(config, opts...)
 	if config.Model == nil {
 		return nil, fmt.Errorf("model is required")
 	}
@@ -182,7 +217,9 @@ func CreatePEVAgent[S any](
 	setVerificationResult func(S, string) S,
 	getFinalAnswer func(S) string,
 	setFinalAnswer func(S, string) S,
+	opts ...CreateAgentOption,
 ) (*graph.StateRunnable[S], error) {
+	config = applyPEVOptions(config, opts...)
 	if config.Model == nil {
 		return nil, fmt.Errorf("model is required")
 	}

--- a/prebuilt/plan_execute_options_test.go
+++ b/prebuilt/plan_execute_options_test.go
@@ -1,0 +1,62 @@
+package prebuilt
+
+import "testing"
+
+func TestApplyManusOptions(t *testing.T) {
+	t.Run("options fill unset fields", func(t *testing.T) {
+		got := applyManusOptions(ManusConfig{},
+			WithWorkDir("/tmp/w"),
+			WithPlanPath("/tmp/plan.md"),
+			WithNotesPath("/tmp/notes.md"),
+			WithOutputPath("/tmp/out.md"),
+			WithAutoSave(true),
+			WithVerbose(true),
+		)
+		if got.WorkDir != "/tmp/w" || got.PlanPath != "/tmp/plan.md" ||
+			got.NotesPath != "/tmp/notes.md" || got.OutputPath != "/tmp/out.md" ||
+			!got.AutoSave || !got.Verbose {
+			t.Fatalf("options not folded into config: %+v", got)
+		}
+	})
+
+	t.Run("config takes precedence over options", func(t *testing.T) {
+		cfg := ManusConfig{WorkDir: "/keep", AutoSave: true, Verbose: true}
+		got := applyManusOptions(cfg, WithWorkDir("/override"), WithAutoSave(false))
+		if got.WorkDir != "/keep" {
+			t.Errorf("WorkDir = %q, want /keep", got.WorkDir)
+		}
+		if !got.AutoSave {
+			t.Error("AutoSave should stay true when config set it")
+		}
+	})
+
+	t.Run("no options is a no-op", func(t *testing.T) {
+		cfg := ManusConfig{WorkDir: "/x"}
+		if got := applyManusOptions(cfg); got != cfg {
+			t.Errorf("no-op changed config: %+v", got)
+		}
+	})
+}
+
+func TestApplyPEVOptions(t *testing.T) {
+	t.Run("options fill unset fields", func(t *testing.T) {
+		got := applyPEVOptions(PEVAgentConfig{},
+			WithMaxRetries(5),
+			WithSystemMessage("sys"),
+			WithVerificationPrompt("verify"),
+			WithVerbose(true),
+		)
+		if got.MaxRetries != 5 || got.SystemMessage != "sys" ||
+			got.VerificationPrompt != "verify" || !got.Verbose {
+			t.Fatalf("options not folded into config: %+v", got)
+		}
+	})
+
+	t.Run("config takes precedence over options", func(t *testing.T) {
+		cfg := PEVAgentConfig{MaxRetries: 2, SystemMessage: "keep"}
+		got := applyPEVOptions(cfg, WithMaxRetries(9), WithSystemMessage("override"))
+		if got.MaxRetries != 2 || got.SystemMessage != "keep" {
+			t.Errorf("config not preserved: %+v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Extend shared `CreateAgentOptions` + `With*` helpers so `CreatePlanningAgent`, `CreateManusAgent`, and `CreatePEVAgent` accept one consistent functional-option surface.
- Wire options into `CreateManusAgent` / `CreatePEVAgentMap` / `CreatePEVAgent` (previously a dead `opts` param on Manus).
- Deprecate `ManusConfig` / `PEVAgentConfig` in godoc while keeping them working — non-zero config fields take precedence over options, so all existing callers, examples, and tests are unaffected.
- Add a "Choosing a Plan-Execute Agent" doc section and table tests for the option-folding helpers.

This is a non-breaking convergence: the three agents keep their distinct graph topologies; only the config API is unified.

Closes #101

## Test plan
- [x] `go build ./...` (main module)
- [x] `cd examples && go build ./planning_agent/ ./manus_agent/ ./pev_agent/ ./tree_of_thoughts/ ./pi_agent/`
- [x] `go vet ./prebuilt/...`
- [x] `go test ./prebuilt/...` (incl. new TestApplyManusOptions / TestApplyPEVOptions)